### PR TITLE
Humble

### DIFF
--- a/autoreporter_addons/humble/reporter.py
+++ b/autoreporter_addons/humble/reporter.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+from artemis.reporting.base.language import Language
+from artemis.reporting.base.normal_form import (
+    NormalForm,
+    get_domain_normal_form,
+    get_domain_score,
+)
+from artemis.reporting.base.report import Report
+from artemis.reporting.base.report_type import ReportType
+from artemis.reporting.base.reporter import Reporter
+from artemis.reporting.base.templating import ReportEmailTemplateFragment
+from artemis.reporting.utils import get_top_level_target
+
+
+class HumbleReporter(Reporter):  # type: ignore
+    MISSING_SECURITY_HEADER = ReportType("missing_security_header")
+
+    @staticmethod
+    def create_reports(task_result: Dict[str, Any], language: Language) -> List[Report]:
+        if task_result["headers"]["receiver"] != "humble":
+            return []
+
+        if not isinstance(task_result["result"], list):
+            return []
+
+        result = []
+        for item in task_result["result"]:
+            if item["confidence"] == "CONFIRMED":
+                result.append(
+                    Report(
+                        top_level_target=get_top_level_target(task_result),
+                        target=item["domain"],
+                        report_type=HumbleReporter.MISSING_SECURITY_HEADER,
+                        additional_data={
+                            "message_en": item["info"],
+                        },
+                        timestamp=task_result["created_at"],
+                    )
+                )
+        return result
+
+    @staticmethod
+    def get_email_template_fragments() -> List[ReportEmailTemplateFragment]:
+        return [
+            ReportEmailTemplateFragment.from_file(
+                str(Path(__file__).parents[0] / "template_missing_security_header.jinja2"), priority=10
+            ),
+        ]
+
+    @staticmethod
+    def get_scoring_rules() -> Dict[ReportType, Callable[[Report], List[int]]]:
+        """See the docstring in the parent class."""
+        return {HumbleReporter.MISSING_SECURITY_HEADER: lambda report: [get_domain_score(report.target)]}
+
+    @staticmethod
+    def get_normal_form_rules() -> Dict[ReportType, Callable[[Report], NormalForm]]:
+        """See the docstring in the Reporter class."""
+        return {
+            HumbleReporter.MISSING_SECURITY_HEADER: lambda report: Reporter.dict_to_tuple(
+                {
+                    "type": report.report_type,
+                    "target": get_domain_normal_form(report.target),
+                    "message": report.additional_data["message_en"],
+                }
+            )
+        }

--- a/autoreporter_addons/humble/template_missing_security_header.jinja2
+++ b/autoreporter_addons/humble/template_missing_security_header.jinja2
@@ -1,0 +1,20 @@
+{% if "missing_security_header" in data.contains_type %}
+    <li>{% trans %}We identified that not all possible security headers are set correctly:{% endtrans %}
+        <ul>
+            {% for report in data.reports %}
+                {% if report.report_type == "missing_security_header" %}
+                    <li>
+                        {{ report.target }}: {{ _(report.additional_data.message_en) }}
+                        {{ report_meta(report) }}
+                    </li>
+                {% endif %}
+            {% endfor %}
+        </ul>
+        <p>
+            {% trans trimmed %}
+                Please verify the configuration, and, if a security header is missing, change it. Security 
+                headers can have a deep impact in protecting your application against attacks.
+            {% endtrans %}
+        </p>
+    </li>
+{% endif %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,3 +47,4 @@ services:
       - ./Artemis-modules-extra/autoreporter_addons/ssl_checks/:/opt/artemis/reporting/modules/ssl_checks/
       - ./Artemis-modules-extra/autoreporter_addons/sqlmap/:/opt/artemis/reporting/modules/sqlmap/
       - ./Artemis-modules-extra/autoreporter_addons/dns_reaper/:/opt/artemis/reporting/modules/dns_reaper/
+      - ./Artemis-modules-extra/autoreporter_addons/humble/:/opt/artemis/reporting/modules/humble/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,16 @@ services:
     restart: always
     command: "python3 -m artemis.modules.karton_ssl_checks"
 
+  karton-humble:
+    build:
+      context: Artemis-modules-extra
+      dockerfile: karton_humble/Dockerfile
+    volumes: ["./docker/karton.ini:/etc/karton/karton.ini", "${DOCKER_COMPOSE_ADDITIONAL_SHARED_DIRECTORY:-./shared}:/shared/"]
+    depends_on: [karton-logger, redis]
+    env_file: .env
+    restart: always
+    command: "python3 -m artemis.modules.karton_humble"
+
   autoreporter:
     volumes:
       - ./Artemis-modules-extra/extra_modules_config.py:/opt/extra_modules_config.py

--- a/karton_humble/Dockerfile
+++ b/karton_humble/Dockerfile
@@ -1,0 +1,11 @@
+FROM certpl/artemis:latest
+
+RUN apk add git
+
+RUN git clone https://github.com/rfc-st/humble.git --branch master /humble
+
+RUN pip install -r /humble/requirements.txt
+
+WORKDIR /opt/
+
+COPY karton_humble/karton_humble.py /opt/artemis/modules/

--- a/karton_humble/karton_humble.py
+++ b/karton_humble/karton_humble.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+
+from artemis.binds import TaskStatus, TaskType
+from artemis.module_base import ArtemisBase
+from karton.core import Task
+
+
+def process_json_data(result):
+    messages = []
+
+    # Iterate through key-value pairs in the result
+    for key, value in result.items():
+        # Split the key to extract the relevant part
+        key_parts = key.replace("[", "").replace("]", "").split(". ")
+
+        # Check if the key has the expected structure
+        if len(key_parts) >= 2:
+            category = key_parts[1].capitalize()
+
+            # Check if the key is not in the excluded categories and there are relevant values
+            if (key_parts[1].lower() != "info" and
+                    key not in ["[2. Fingerprint HTTP Response Headers]",
+                                "[3. Deprecated HTTP Response Headers/Protocols and Insecure Values]",
+                                "[4. Empty HTTP Response Headers Values]",
+                                "[5. Browser Compatibility for Enabled HTTP Security Headers]"]
+                    and (isinstance(value, dict) or (isinstance(value, list)
+                                                     and any(subvalue for subvalue in value
+                                                             if subvalue and subvalue not in [
+                                                                "Nothing to report, all seems OK!",
+                                                                "No HTTP security headers are enabled."])))):
+                messages.append(f"{category}:")
+
+                # If the value is a dictionary, iterate through subkey-value pairs
+                if isinstance(value, dict):
+                    for subkey, subvalue in value.items():
+                        # Add subkeys and subvalues to messages
+                        if subvalue and subvalue not in ["Nothing to report, all seems OK!",
+                                                         "No HTTP security headers are enabled."]:
+                            messages.append(f"  {subkey}: {subvalue}")
+
+                # If the value is a list, iterate through list items
+                elif isinstance(value, list):
+                    for item in value:
+                        # Add list items to messages
+                        if item and item not in ["Nothing to report, all seems OK!",
+                                                 "No HTTP security headers are enabled."]:
+                            messages.append(f"  {item}")
+
+    return messages
+
+
+class Humble(ArtemisBase):  # type: ignore
+    """
+    Runs humble -> A HTTP Headers Analyzer
+    """
+
+    identity = "humble"
+    filters = [
+        {"type": TaskType.DOMAIN.value},
+    ]
+
+    def run(self, current_task: Task) -> None:
+        domain = current_task.payload["domain"]
+
+        data = subprocess.check_output(
+            [
+                "python3",
+                "humble.py",
+                "-u",
+                domain,
+                "-b",
+                "-o",
+                "json",
+            ],
+            cwd="/humble",
+            stderr=subprocess.DEVNULL,
+        )
+
+        # strip the first 74 and the last characters from the output to get the location and filename of the output file
+        filename = data.decode("ascii", errors="ignore")[74:-1]
+        data_str = open(filename, "r").read()
+
+        # cleanup file
+        subprocess.run(["rm", filename])
+
+        # Check if the input string is empty
+        if data_str.strip():
+            result = json.loads(data_str)
+        else:
+            result = []
+
+        # Parse the JSON data
+        messages = process_json_data(result)
+
+        if messages:
+            status = TaskStatus.INTERESTING
+            status_reason = ", ".join(messages)
+        else:
+            status = TaskStatus.OK
+            status_reason = None
+
+        self.db.save_task_result(task=current_task, status=status, status_reason=status_reason, data=result)
+
+
+if __name__ == "__main__":
+    Humble().loop()

--- a/karton_humble/karton_humble.py
+++ b/karton_humble/karton_humble.py
@@ -69,7 +69,7 @@ class Humble(ArtemisBase):  # type: ignore
                 "python3",
                 "humble.py",
                 "-u",
-                domain,
+                "https://" + domain,
                 "-b",
                 "-o",
                 "json",


### PR DESCRIPTION
This pull request introduces a new scanning modul to artemis called `humble`. 

`humble` is an open source HTTP-Header security scanner ([repo](https://github.com/rfc-st/humble))

I have strongly oriented myself to the implementation of `dnsreaper`. `karton_humble.py` has the class [Humble](https://github.com/cyberamt/Artemis-modules-extra/blob/0932d031682560ee1d0bf49d9fcd89c93faaa90d/karton_humble/karton_humble.py#L54) which is responsible for the call and additionally the function [process_json_data](https://github.com/cyberamt/Artemis-modules-extra/blob/0932d031682560ee1d0bf49d9fcd89c93faaa90d/karton_humble/karton_humble.py#L10C31-L10C31) which parses the output. 

The parser tries to parse missing security headers so that artemis can display them as interesting findings. If necessary, the parser needs a little refinement so that depricated headers and the like are correctly recognized as "interesting".

Please review the changes and let me know if there are any concerns or suggestions for improvement.
