### PR TITLE
Detectem 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,22 @@ services:
     restart: always
     command: "python3 -m artemis.modules.karton_ssl_checks"
 
+  karton_detectem:
+    build:
+      context: Artemis-modules-extra
+      dockerfile: karton_detectem/Dockerfile
+    volumes: ["./docker/karton.ini:/etc/karton/karton.ini", "${DOCKER_COMPOSE_ADDITIONAL_SHARED_DIRECTORY:-./shared}:/shared/"]
+    depends_on: [karton-logger, redis, detectem_splash]
+    environment:
+      - SETUP_SPLASH=False
+      - SPLASH_URL=http://detectem_splash:8050
+    env_file: .env
+    restart: always
+    command: "python3 -m artemis.modules.karton_detectem"
+
+  detectem_splash:
+    image: scrapinghub/splash:3.0
+
   autoreporter:
     volumes:
       - ./Artemis-modules-extra/extra_modules_config.py:/opt/extra_modules_config.py

--- a/karton_detectem/Dockerfile
+++ b/karton_detectem/Dockerfile
@@ -1,0 +1,10 @@
+FROM certpl/artemis:latest
+
+RUN apk add --update build-base libxml2-dev libxslt-dev
+
+RUN pip install setuptools==45
+RUN pip install detectem
+
+WORKDIR /opt/
+
+COPY karton_detectem/karton_detectem.py /opt/artemis/modules/

--- a/karton_detectem/karton_detectem.py
+++ b/karton_detectem/karton_detectem.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+
+from artemis.binds import TaskStatus, TaskType
+from artemis.module_base import ArtemisBase
+from karton.core import Task
+
+
+class Detectem(ArtemisBase):  # type: ignore
+    """
+    Runs detectem -> detectem is a specialized software detector
+    """
+
+    identity = "detectem"
+    filters = [
+        {"type": TaskType.DOMAIN.value},
+    ]
+
+    def run(self, current_task: Task) -> None:
+        domain = current_task.payload["domain"]
+
+        data = subprocess.check_output(
+            [
+                "det",
+                "https://" + domain,
+                "--format",
+                "json",
+                "--metadata"
+            ],
+            stderr=subprocess.DEVNULL,
+        )
+
+        data_str = data.decode("ascii", errors="ignore")
+
+        # Check if the input string is empty
+        if data_str.strip():
+            result = json.loads(data_str)
+        else:
+            result = []
+
+        messages = []
+        for item in result[0]["softwares"]:
+            messages.append(item["name"])
+
+        if messages:
+            status = TaskStatus.INTERESTING
+            status_reason = ", ".join(messages)
+        else:
+            status = TaskStatus.OK
+            status_reason = None
+
+        self.db.save_task_result(task=current_task, status=status, status_reason=status_reason, data=result)
+
+
+if __name__ == "__main__":
+    Detectem().loop()


### PR DESCRIPTION
This pull request introduces a new scanning modul to artemis called `detectem.`

`detectem` is an open source alternative to tools like `wappalyzer`. It is not as powerful as wappalizer, but since wappalizer is no longer available as open source software, it is a viable alternative ([repo](https://github.com/alertot/detectem))

`detectem` uses [splash](https://github.com/scrapinghub/splash) to analyze websites, therefore it is necessary to start a splash container in addition to the `dectectem` container. Otherwise, the code in `karton_detectem.py` is very straightforward. Whenever `detectem` recognizes a software, this is first highlighted as interesting, the exact output, software versions and location can then be viewed in the details. 

Small side note. It is necessary to set `setuptools` to version 45. `detectem` has unfortunately not been updated for a long time and with a newer version of `setuptools` the install failed due to a change in `setuptools` :grimacing: ([related issue](https://github.com/pypa/setuptools/issues/2017)).

