### PR TITLE
Added testcases for moodle scanner

### DIFF
--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -15,6 +15,15 @@ services:
     command: python -m unittest discover
     env_file: env.test
 
+  test-moodle-scanner:
+    build:
+      context: .
+      dockerfile: karton_moodle_scanner/Dockerfile
+    command: python -m unittest discover
+    env_file: env.test
+    depends_on:
+      - test-service-moodle
+
   test-ssl_checks:
     build:
       context: .
@@ -55,3 +64,27 @@ services:
     environment:
       - POSTGRES_USER=root
       - POSTGRES_PASSWORD=root
+
+  test-service-moodle:
+    image: bitnami/moodle:4.2
+    ports:
+      - "8080:8080"
+      - "8443:8443"
+    environment:
+      - MOODLE_DATABASE_HOST=test-service-moodle-db
+      - MOODLE_DATABASE_PORT_NUMBER=3306
+      - MOODLE_DATABASE_USER=bn_moodle
+      - MOODLE_DATABASE_NAME=bitnami_moodle
+      - MOODLE_DATABASE_PASSWORD=bitnami123
+      - MOODLE_USERNAME=admin
+      - MOODLE_PASSWORD=Admin123!
+    depends_on:
+      - test-service-moodle-db
+
+  test-service-moodle-db:
+    image: mariadb:10.6
+    environment:
+      - MYSQL_ROOT_PASSWORD=root123
+      - MYSQL_USER=bn_moodle
+      - MYSQL_PASSWORD=bitnami123
+      - MYSQL_DATABASE=bitnami_moodle

--- a/karton_moodle_scanner/test_moodle_scanner.py
+++ b/karton_moodle_scanner/test_moodle_scanner.py
@@ -1,0 +1,37 @@
+from test.base import ArtemisModuleTestCase
+
+from artemis.binds import TaskStatus, TaskType, WebApplication
+from artemis.modules.karton_moodle_scanner import MoodleScanner
+from karton.core import Task
+
+
+class MoodleScannerTestCase(ArtemisModuleTestCase):
+    karton_class = MoodleScanner
+
+    def test_moodle_detection(self) -> None:
+        task = Task(
+            {"type": TaskType.WEBAPP.value, "webapp": WebApplication.UNKNOWN.value},
+            payload={"url": "http://test-service-moodle:8080"},
+        )
+        self.run_task(task)
+        (call,) = self.mock_db.save_task_result.call_args_list
+        self.assertEqual(call.kwargs["status"], TaskStatus.INTERESTING)
+        self.assertEqual(call.kwargs["data"][0]["extracted_version"], "4.2")
+        self.assertEqual(
+            call.kwargs["status_reason"],
+            "Found Moodle 4.2 installation at http://test-service-moodle:8080",
+        )
+
+    def test_moodle_vulnerabilities(self) -> None:
+        task = Task(
+            {"type": TaskType.WEBAPP.value, "webapp": WebApplication.MOODLE.value},
+            payload={"url": "http://test-service-moodle:8080"},
+        )
+        self.run_task(task)
+        (call,) = self.mock_db.save_task_result.call_args_list
+        # Here we expect no vulnerabilities since we're using latest version
+        self.assertEqual(call.kwargs["status"], TaskStatus.OK)
+        self.assertEqual(
+            call.kwargs["status_reason"],
+            "No vulnerabilities found in Moodle installation",
+        )


### PR DESCRIPTION
I've set up:
1. A Moodle test service using the official Bitnami image (version 4.2)
2. A MariaDB database service for Moodle
3. Test cases that verify:
  - Moodle detection and version extraction
  - Vulnerability scanning (using a latest version which should have no vulnerabilities)