### PR TITLE
run tests once per day

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [ '**' ]
   schedule:
-    - cron: '12 0 * * *'
+    - cron: '0 12 * * *'
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: "tests"
 on:
   pull_request:
     branches: [ '**' ]
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [ '**' ]
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '12 0 * * *'
 
 jobs:
   test:


### PR DESCRIPTION
Rationale: we do not often run tests, so integration may break and we wouldn't notice